### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,4 +57,5 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     setup_requires=setup_requirements,
+    python_requires='>=3.5',
 )


### PR DESCRIPTION
[`python_requires`](https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires) prevents pip from installing the package on an incompatible version of Python.