### PR TITLE
Fix for #192 - support aiobotocore 0.12

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.5.0
+current_version = 6.6.0
 
 [bumpversion:file:setup.py]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.6.0
+current_version = 7.0.0
 
 [bumpversion:file:setup.py]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 dist: xenial
 python:
+- 3.8
 - 3.7
 - 3.6
-- 3.5
 install: pip install -U tox-travis -r requirements_dev.txt
 script:
 - tox

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,10 +2,10 @@
 History
 =======
 
-6.6.0 (2020-03-12)
+7.0.0 (2020-03-12)
 
 * Upgrade to aiobotocore 0.12
-* Bumepd minimum python version to 3.6
+* Bumped minimum python version to 3.6, adding support for 3.8
 * Eliminate use of deprecated loop arguments
 
 6.5.0 (2020-02-20)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+6.6.0 (2020-03-12)
+
+* Upgrade to aiobotocore 0.12
+* Bumepd minimum python version to 3.6
+* Eliminate use of deprecated loop arguments
+
 6.5.0 (2020-02-20)
 ------------------
 

--- a/aioboto3/__init__.py
+++ b/aioboto3/__init__.py
@@ -6,7 +6,7 @@ from aioboto3.session import Session
 
 __author__ = """Terry Cain"""
 __email__ = 'terry@terrys-home.co.uk'
-__version__ = '6.6.0'
+__version__ = '7.0.0'
 
 DEFAULT_SESSION = None
 

--- a/aioboto3/__init__.py
+++ b/aioboto3/__init__.py
@@ -6,7 +6,7 @@ from aioboto3.session import Session
 
 __author__ = """Terry Cain"""
 __email__ = 'terry@terrys-home.co.uk'
-__version__ = '6.5.0'
+__version__ = '6.6.0'
 
 DEFAULT_SESSION = None
 
@@ -57,20 +57,20 @@ def _get_default_session(**kwargs):
     return DEFAULT_SESSION
 
 
-def client(*args, loop=None, **kwargs):
+def client(*args, **kwargs):
     """
     Create a low-level service client by name using the default session.
     See :py:meth:`aioboto3.session.Session.client`.
     """
-    return _get_default_session(loop=loop).client(*args, **kwargs)
+    return _get_default_session().client(*args, **kwargs)
 
 
-def resource(*args, loop=None, **kwargs):
+def resource(*args, **kwargs):
     """
     Create a resource service client by name using the default session.
     See :py:meth:`aioboto3.session.Session.resource`.
     """
-    return _get_default_session(loop=loop).resource(*args, **kwargs)
+    return _get_default_session().resource(*args, **kwargs)
 
 
 # Set up logging to ``/dev/null`` like a library is supposed to.

--- a/aioboto3/action.py
+++ b/aioboto3/action.py
@@ -1,10 +1,8 @@
 import logging
-from typing import cast, AsyncIterator, Any
 
-from botocore import xform_name
 from boto3.resources.action import ServiceAction
 from boto3.resources.params import create_request_parameters
-
+from botocore import xform_name
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +67,7 @@ class AioBatchAction(ServiceAction):
             params.update(kwargs)
 
             logger.debug('Calling %s:%s with %r',
-                        service_name, operation_name, params)
+                         service_name, operation_name, params)
 
             response = await (getattr(client, operation_name)(**params))
 

--- a/aioboto3/dynamodb/table.py
+++ b/aioboto3/dynamodb/table.py
@@ -58,7 +58,6 @@ class BatchWriter(object):
         """
         self._table_name = table_name
         self._client = client
-        self._loop = self._client._endpoint._loop  # Yes its dirty
         self._items_buffer = []
         self._flush_amount = flush_amount
         self._overwrite_by_pkeys = overwrite_by_pkeys
@@ -117,4 +116,4 @@ class BatchWriter(object):
         while self._items_buffer:
             await self._flush()
             if self._items_buffer and self._on_exit_loop_sleep:
-                await asyncio.sleep(self._on_exit_loop_sleep, loop=self._loop)
+                await asyncio.sleep(self._on_exit_loop_sleep)

--- a/aioboto3/resources.py
+++ b/aioboto3/resources.py
@@ -106,8 +106,8 @@ class AIOWaiterAction(object):
         params.update(kwargs)
 
         logger.debug('Calling %s:%s with %r',
-                    parent.meta.service_name,
-                    self._waiter_resource_name, params)
+                     parent.meta.service_name,
+                     self._waiter_resource_name, params)
 
         client = parent.meta.client
         waiter = client.get_waiter(client_waiter_name)
@@ -132,8 +132,8 @@ class AIOWaiterAction(object):
         params.update(kwargs)
 
         logger.debug('Calling %s:%s with %r',
-                    parent.meta.service_name,
-                    self._waiter_resource_name, params)
+                     parent.meta.service_name,
+                     self._waiter_resource_name, params)
 
         client = parent.meta.client
         waiter = client.get_waiter(client_waiter_name)

--- a/aioboto3/s3/inject.py
+++ b/aioboto3/s3/inject.py
@@ -139,7 +139,7 @@ async def upload_fileobj(self, Fileobj: BinaryIO, Bucket: str, Key: str, ExtraAr
     :type Config: boto3.s3.transfer.TransferConfig
     :param Config: The transfer configuration to be used when performing the
         upload.
-        
+
     :type Processing: method
     :param Processing: A method which takes a bytes buffer and convert it
         by custom logic.
@@ -224,14 +224,16 @@ async def upload_fileobj(self, Fileobj: BinaryIO, Bucket: str, Key: str, ExtraAr
                     break
                 multipart_payload += data
 
-            # If file has ended but chunk has some data in it, upload it, else if file ended just after a chunk then exit
+            # If file has ended but chunk has some data in it, upload it,
+            # else if file ended just after a chunk then exit
             if not multipart_payload:
                 break
 
             if Processing:
                 multipart_payload = Processing(multipart_payload)
 
-            await io_queue.put({'Body': multipart_payload, 'Bucket': Bucket, 'Key': Key, 'PartNumber': part, 'UploadId': upload_id})
+            await io_queue.put({'Body': multipart_payload, 'Bucket': Bucket, 'Key': Key,
+                                'PartNumber': part, 'UploadId': upload_id})
             logger.debug('Added part to io_queue')
             expected_parts += 1
 

--- a/aioboto3/session.py
+++ b/aioboto3/session.py
@@ -34,14 +34,13 @@ class Session(boto3.session.Session):
     :param profile_name: The name of a profile to use. If not given, then
                          the default profile is used.
     """
-    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
-                 aws_session_token=None, region_name=None,
-                 botocore_session=None, profile_name=None, loop=None):
+    def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None, region_name=None,
+                 botocore_session=None, profile_name=None):
         if botocore_session is not None:
             self._session = botocore_session
         else:
             # Create a new default session
-            self._session = aiobotocore.session.get_session(loop=loop)
+            self._session = aiobotocore.session.get_session()
 
         # Setup custom user-agent string if it isn't already customized
         if self._session.user_agent_name == 'Botocore':

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.5.0
+current_version = 6.6.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.6.0
+current_version = 7.0.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {
 
 setup(
     name='aioboto3',
-    version='6.6.0',
+    version='7.0.0',
     description="Async boto3 wrapper",
     long_description=readme + '\n\n' + history,
     author="Terry Cain",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'aiobotocore[boto3]~=0.11.1'
+    'aiobotocore[boto3]>=0.12'
 ]
 
 setup_requirements = [
@@ -32,7 +32,7 @@ extras_require = {
 
 setup(
     name='aioboto3',
-    version='6.5.0',
+    version='6.6.0',
     description="Async boto3 wrapper",
     long_description=readme + '\n\n' + history,
     author="Terry Cain",
@@ -50,13 +50,13 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     test_suite='tests',
     tests_require=test_requirements,
     setup_requires=setup_requirements,
     extras_require=extras_require,
-    python_requires='>=3.5',
+    python_requires='>=3.6',
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def s3_key_name():
 
 @pytest.fixture
 def dynamodb_resource(request, region, config, event_loop, dynamodb2_server):
-    session = Session(region_name=region, loop=event_loop, **moto_config())
+    session = Session(region_name=region, **moto_config())
 
     async def f():
         return session.resource('dynamodb', region_name=region, endpoint_url=dynamodb2_server, config=config)
@@ -79,7 +79,7 @@ def dynamodb_resource(request, region, config, event_loop, dynamodb2_server):
 
 @pytest.fixture
 def s3_client(request, region, config, event_loop, s3_server, bucket_name):
-    session = Session(region_name=region, loop=event_loop, **moto_config())
+    session = Session(region_name=region, **moto_config())
 
     async def f():
         return session.client('s3', region_name=region, endpoint_url=s3_server, config=config)
@@ -96,7 +96,7 @@ def s3_client(request, region, config, event_loop, s3_server, bucket_name):
 
 @pytest.fixture
 def s3_resource(request, region, config, event_loop, s3_server, bucket_name):
-    session = Session(region_name=region, loop=event_loop, **moto_config())
+    session = Session(region_name=region, **moto_config())
 
     async def f():
         return session.resource('s3', region_name=region, endpoint_url=s3_server, config=config)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -14,7 +14,7 @@ async def test_getting_client(event_loop):
     """Simple getting of client."""
     aioboto3.DEFAULT_SESSION = None
 
-    async with aioboto3.client('ssm', loop=event_loop, region_name='eu-central-1') as client:
+    async with aioboto3.client('ssm', region_name='eu-central-1') as client:
         assert isinstance(client, AioBaseClient)
 
 
@@ -23,7 +23,7 @@ async def test_getting_resource_cm(event_loop):
     """Simple getting of resource."""
     aioboto3.DEFAULT_SESSION = None
 
-    async with aioboto3.resource('dynamodb', loop=event_loop, region_name='eu-central-1') as resource:
+    async with aioboto3.resource('dynamodb', region_name='eu-central-1') as resource:
         assert isinstance(resource.meta.client, AioBaseClient)
 
 
@@ -32,6 +32,6 @@ async def test_getting_resource(event_loop):
     """Simple getting of resource."""
     aioboto3.DEFAULT_SESSION = None
 
-    resource = aioboto3.resource('dynamodb', loop=event_loop, region_name='eu-central-1')
+    resource = aioboto3.resource('dynamodb', region_name='eu-central-1')
     assert isinstance(resource.meta.client, AioBaseClient)
     await resource.close()

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
-envlist = py35, py36, py37, flake8
+envlist = py36, py37, py38, flake8
 
 [travis]
 python =
+    3.8: py38
     3.7: py37
     3.6: py36
-    3.5: py35
-# https://github.com/PyCQA/pycodestyle/issues/753
-#    3.5: flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
- Update requirements to aiobotocore 0.12 or later.
- remove use of loop argument
- fix a few flake8 warnings
- require python 3.6 or later
- support python 3.8
- eliminate @async_generator uses
- bump version to 6.6.0

Note that this PR abandons support for python3.5 in favor of adding python3.8 support since 3.5 is no longer getting anything but security fixes.