### PR TITLE
Wrap coroutine objects in a task prior to calling wait.

### DIFF
--- a/aioboto3/s3/inject.py
+++ b/aioboto3/s3/inject.py
@@ -293,7 +293,10 @@ async def upload_fileobj(self, Fileobj: BinaryIO, Bucket: str, Key: str, ExtraAr
     # So by this point all of the file is read and in a queue
 
     # wait for either io queue is finished, or an exception has been raised
-    _, pending = await asyncio.wait({io_queue.join(), exception_event.wait()}, return_when=asyncio.FIRST_COMPLETED)
+    _, pending = await asyncio.wait(
+        {asyncio.create_task(io_queue.join()), asyncio.create_task(exception_event.wait())},
+        return_when=asyncio.FIRST_COMPLETED
+    )
 
     if exception_event.is_set() or len(finished_parts) != expected_parts:
         # An exception during upload or for some reason the finished parts dont match the expected parts, cancel upload


### PR DESCRIPTION
When running tests with newer versions of python, both in this project and in downstream consumers, the following warning is shown:
```
tests/test_s3.py::test_s3_copy_from
/some/path/src/aioboto3/aioboto3/s3/inject.py:296: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
    _, pending = await asyncio.wait({io_queue.join(), exception_event.wait()}, return_when=asyncio.FIRST_COMPLETED)
```

To avoid issues with 3.11 and to remove this warning, this change wraps coroutine objects in a task prior to passing it to wait, as suggested by [the stdlib docs](https://docs.python.org/3/library/asyncio-task.html#waiting-primitives). 

Hope this is useful, and thanks for all the work on aioboto!