### PR TITLE
Fix dynamo db batch writer data loss bug

### DIFF
--- a/aioboto3/dynamodb/table.py
+++ b/aioboto3/dynamodb/table.py
@@ -111,14 +111,15 @@ class BatchWriter(object):
             RequestItems={self._table_name: items_to_send})
         unprocessed_items = response['UnprocessedItems']
 
-        if unprocessed_items and unprocessed_items[self._table_name]:
-            # Any unprocessed_items are immediately added to the
-            # next batch we send.
-            self._items_buffer.extend(unprocessed_items[self._table_name])
-        else:
-            self._items_buffer = []
+        if not unprocessed_items:
+            unprocessed_items = {}
+        item_list = unprocessed_items.get(self._table_name, [])
+        # Any unprocessed_items are immediately added to the
+        # next batch we send.
+        self._items_buffer.extend(item_list)
         logger.debug(
-            "Batch write sent %s, unprocessed: %s", len(items_to_send), len(self._items_buffer)
+            "Batch write sent %s, unprocessed: %s, buffer %s",
+            len(items_to_send), len(item_list), len(self._items_buffer)
         )
 
     async def __aenter__(self):


### PR DESCRIPTION
This patch fixes the data loss bug (https://github.com/terrycain/aioboto3/issues/246) which can occur when concurrent tasks use the same dynamodb batch writer. 

Also brings the code back in line with the boto3 code per https://github.com/boto/boto3/pull/3279


