### PR TITLE
Update s3 streaming example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -162,11 +162,9 @@ Here we pull the object from S3 in chunks and serve it out to a HTTP request via
             resp.content_length = ob_info["content-length"]
             await resp.prepare(request)
 
-            async with s3_ob["Body"] as stream:
-                file_data = await stream.read(chunk_size)
-                while file_data:
-                    await resp.write(file_data)
-                    file_data = await stream.read(chunk_size)
+            stream = s3_ob["Body"]
+            while file_data := stream.read(chunk_size):
+                await resp.write(file_data)
 
         return resp
 


### PR DESCRIPTION
As discussed here: https://github.com/terrycain/aioboto3/issues/266 the Body of an s3 object response is now a `StreamingBody` instance which has a `read(amt)` method, while the `__aenter__` method on that same instance returns the underlying aiohttp client response object, where `read()` takes no arguments and does not stream (returns the entire body) I thought it would be prudent to update the example in the documentation.

The current example will result in a `TypeError` as disclosed in the issue referenced at the top of this commit:

```
TypeError: ClientResponse.read() takes 1 positional argument but 2 were given
```

... I additionally updated the example to be a bit more terse by using the walrus operator to be able to evaluate the read assignment in the loop.