### PR TITLE
Update build system to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ sphinx-rtd-theme = "^1.3.0rc1"
 sphinx-autodoc-typehints = "*"
 
 [build-system]
-requires = ["poetry>=0.12", "poetry-dynamic-versioning"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
updated pep-517 build backend according to https://python-poetry.org/blog/announcing-poetry-1.1.0/#standalone-build-backend
Tools like nix doesn't support building with poetry anymore, and require poetry-core