### PR TITLE
Bump to aiobotocore 2.8.0 + Fixing test by adding digest

### DIFF
--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -71,7 +71,7 @@ _API_DIGESTS = {
     download_fileobj: {'237370745eb02e93a353fa806a64f3701c47995c', '9299d1abbd9d5c311e8a824a438e150ff24ebcd7', '91c0900c26c0078b623b9550c4fb9ef6afc4a528'},
     upload_fileobj: {'d1db027e51d37cf1476377cfda436810b813044b', '3b953e17cfc4a3c6ad75c3890af60aebeea4bee8'},
     upload_file: {'063eaca7bec14af8ccd041e3a87ff5c9ef7252ca', 'ad899c968fdfc294b46c54efbcb9912c5675ba09', 'df7552000d9111f71a05bd9880e9b6ef0f2f21bc'},
-    copy: {'c4423d0a6d3352553befdf0387987c09812fcaff', 'e8154a4de3b97dd2ab29d250c005b03e8fc7ed71'},
+    copy: {'c4423d0a6d3352553befdf0387987c09812fcaff', 'e8154a4de3b97dd2ab29d250c005b03e8fc7ed71', '7f9edd96f418e09c00d26538a7382b217e0843e5'},
     S3TransferConfig.__init__: {'f418b3dab3c6f073f19feaf1172359bdc3863e22'},
 }
 


### PR DESCRIPTION
Adding @huonw's PR + Fixes to see if we can get the changes merged faster!
@terrycain 

---

https://github.com/aio-libs/aiobotocore/releases/tag/2.8.0

This in particular allows using botocore>=1.32.1, which comes with a massive decrease in installed size: 83MB -> 20MB (see https://github.com/boto/botocore/issues/2365#issuecomment-1813447304 and/or https://github.com/aio-libs/aiobotocore/issues/1056 for more details).

---
Thanks for aioboto3! ^2